### PR TITLE
move sql driver imports from lib to cmd

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -8,6 +8,10 @@ import (
 	"text/template"
 
 	"github.com/CloudCom/goose/lib/goose"
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/ziutek/mymysql/godrv"
 )
 
 // global options. available to any subcommands.

--- a/lib/goose/dialect.go
+++ b/lib/goose/dialect.go
@@ -2,7 +2,7 @@ package goose
 
 import (
 	"database/sql"
-	"github.com/mattn/go-sqlite3"
+	"strings"
 )
 
 // SqlDialect abstracts the details of specific SQL dialects
@@ -115,9 +115,8 @@ func (m Sqlite3Dialect) insertVersionSql() string {
 func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
 
-	switch err.(type) {
-	case sqlite3.Error:
-		return nil, ErrTableDoesNotExist
+	if err != nil && strings.Contains(err.Error(), "no such table") {
+		err = ErrTableDoesNotExist
 	}
 	return rows, err
 }

--- a/lib/goose/migrate.go
+++ b/lib/goose/migrate.go
@@ -12,11 +12,6 @@ import (
 	"strings"
 	"text/template"
 	"time"
-
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
-	_ "github.com/mattn/go-sqlite3"
-	_ "github.com/ziutek/mymysql/godrv"
 )
 
 var (


### PR DESCRIPTION
This moves all the sql driver imports out of the `lib` package into `cmd`.
This is so that compiling apps which import goose don't take forever to compile drivers they don't need.

See also https://bitbucket.org/liamstask/goose/issue/47/is-it-necessary-to-import-sql-drivers-in
