### PR TITLE
remove go tip from travis build matrix. it's slow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.3
   - 1.4
-  - tip
 
 before_install:
   # install linting tools


### PR DESCRIPTION
I want to remove `1.3` too, but I figure we can all agree on this at least.
