### PR TITLE
change the behavior of `goose create` to use flag & default to 'sql'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ goose provides several commands to help manage your database schema.
 
 ## create
 
-Create a new Go migration.
+Create a new SQL migration.
 
     $ goose create AddSomeColumns
-    $ goose: created db/migrations/20130106093224_AddSomeColumns.go
+    $ goose: created db/migrations/20130106093224_AddSomeColumns.sql
 
 Edit the newly created script to define the behavior of your migration.
 
-You can also create an SQL migration:
+You can also create a GO migration:
 
-    $ goose create AddSomeColumns sql
-    $ goose: created db/migrations/20130106093224_AddSomeColumns.sql
+    $ goose create -type go AddSomeColumns
+    $ goose: created db/migrations/20130106093224_AddSomeColumns.go
 
 ## up
 

--- a/cmd/goose/cmd.go
+++ b/cmd/goose/cmd.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
 )
 
 // shamelessly snagged from the go tool
@@ -19,9 +21,13 @@ type Command struct {
 }
 
 func (c *Command) Exec(args []string) {
+	name := os.Args[0] + " " + c.Name
 	c.Flag.Usage = func() {
-		// helpFunc(c, c.Name)
+		fmt.Fprintf(os.Stderr, "Usage: %s [args...] %s\n", name, c.Usage)
+		c.Flag.PrintDefaults()
 	}
-	c.Flag.Parse(args)
+	if err := c.Flag.Parse(args); err != nil {
+		os.Exit(1)
+	}
 	c.Run(c, c.Flag.Args()...)
 }

--- a/cmd/goose/cmd_create.go
+++ b/cmd/goose/cmd_create.go
@@ -12,21 +12,22 @@ import (
 
 var createCmd = &Command{
 	Name:    "create",
-	Usage:   "",
+	Usage:   "<migration_name>",
 	Summary: "Create the scaffolding for a new migration",
 	Help:    `create extended help here...`,
 	Run:     createRun,
 }
 
+var migrationType string
+
+func init() {
+	createCmd.Flag.StringVar(&migrationType, "type", "sql", "type of migration to create [sql,go]")
+}
+
 func createRun(cmd *Command, args ...string) {
-
-	if len(args) < 1 {
-		log.Fatal("goose create: migration name required")
-	}
-
-	migrationType := "go" // default to Go migrations
-	if len(args) >= 2 {
-		migrationType = args[1]
+	if len(args) != 1 {
+		cmd.Flag.Usage()
+		os.Exit(1)
 	}
 
 	conf, err := dbConfFromFlags()


### PR DESCRIPTION
closes #4 

```
# ./goose create
Usage: ./goose create [args...] <migration_name>
  -type="sql": type of migration to create [sql,go]

# ./goose create foo         
goose: created /home/phemmer/git/goose/db/migrations/20150522165701_foo.sql

# ./goose create -type sql foo
goose: created /home/phemmer/git/goose/db/migrations/20150522165708_foo.sql
```
