### PR TITLE
Changing travis go build versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: go
 
 go:
-  - 1.3
   - 1.4
+  - 1.5
+  - tip
+
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
 
 before_install:
   # install linting tools


### PR DESCRIPTION
Removing support for go1.3 and adding tip to the`allow_failures` section so that it won't make build take a long time.

This will help give us a heads up if goose breaks with a newer version of go.

<img width="1112" alt="screen shot 2015-09-08 at 10 04 25 pm" src="https://cloud.githubusercontent.com/assets/2306786/9751703/fc283eda-5675-11e5-81c6-e46b13b38a56.png">
