### PR TITLE
Fix direction values in template for Go migrations

### DIFF
--- a/lib/goose/migration_go.go
+++ b/lib/goose/migration_go.go
@@ -62,7 +62,7 @@ func runGoMigration(conf *DBConf, path string, version int64, direction Directio
 		Import:     conf.Driver.Import,
 		Conf:       sb.String(),
 		Direction:  direction,
-		Func:       fmt.Sprintf("%v_%v", strings.ToTitle(direction.String()), version),
+		Func:       fmt.Sprintf("%v_%v", strings.Title(direction.String()), version),
 		InsertStmt: conf.Driver.Dialect.insertVersionSql(),
 	}
 

--- a/lib/goose/templates.go
+++ b/lib/goose/templates.go
@@ -79,7 +79,7 @@ func main() {
 
 	{{ .Func }}(txn)
 
-	err = goose.FinalizeMigration(&conf, txn, {{ .Direction }}, {{ .Version }})
+	err = goose.FinalizeMigration(&conf, txn, {{ if .Direction }} goose.DirectionUp {{ else }} goose.DirectionDown {{ end }}, {{ .Version }})
 	if err != nil {
 		log.Fatal("Commit() failed:", err)
 	}


### PR DESCRIPTION
Having a `Go` migration I realized that they don't work with this fork meanwhile they worked with the [original repo](https://bitbucket.org/liamstask/goose); the go file generated doesn't compile.

I also found that `strings.ToTitle` doesn't return the wanted outcome meanwhile `strings.Title` does.

This PR fix the 2 issues.
